### PR TITLE
Lower the log severity for "unable to connect" nodes

### DIFF
--- a/lib/strategy/strategy.ex
+++ b/lib/strategy/strategy.ex
@@ -56,7 +56,7 @@ defmodule Cluster.Strategy do
             acc
 
           false ->
-            Cluster.Logger.warn(topology, "unable to connect to #{inspect(n)}")
+            Cluster.Logger.debug(topology, "unable to connect to #{inspect(n)}")
             [{n, false} | acc]
 
           :ignored ->


### PR DESCRIPTION
Some nodes might be still discoverable by DNS while the machine itself is put to sleep like what Fly.io does with their auto_start_machines/auto_stop_machines strategies.

As a result of that, unable to connect messages will flood the log stack as polling will continue indefinitely.
